### PR TITLE
Make fellow optional, add admin page

### DIFF
--- a/app/admin/deposits.rb
+++ b/app/admin/deposits.rb
@@ -1,0 +1,18 @@
+ActiveAdmin.register Deposit do
+
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :deposit_number, :date_processed, :check_number, :fellow_id, :fellow_number, :check_date, :payment_by, :payment_type, :deposit_type, :gift_amount_cents, :gift_amount_currency, :period, :amount_cents, :amount_currency, :last_name
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:deposit_number, :date_processed, :check_number, :fellow_id, :fellow_number, :check_date, :payment_by, :payment_type, :deposit_type, :gift_amount_cents, :gift_amount_currency, :period, :amount_cents, :amount_currency, :last_name]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+  
+end

--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -24,5 +24,5 @@
 class Deposit < ApplicationRecord
   monetize :amount_cents
   monetize :gift_amount_cents
-  belongs_to :fellow
+  belongs_to :fellow, optional: true
 end


### PR DESCRIPTION
This PR makes having a fellow for the `belongs_to` relationship optional. It also adds the missing admin page for deposits.