### PR TITLE
Fix the primary and foreign key relationship for fellows and deposits

### DIFF
--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -24,5 +24,5 @@
 class Deposit < ApplicationRecord
   monetize :amount_cents
   monetize :gift_amount_cents
-  belongs_to :fellow
+  belongs_to :fellow, optional: true, primary_key: :fellow_id
 end

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -41,5 +41,5 @@
 #  fellow_id             :integer
 #
 class Fellow < ApplicationRecord
-  has_many :deposits
+  has_many :deposits, foreign_key: :fellow_id, primary_key: :fellow_id
 end


### PR DESCRIPTION
Turns out we want to be real clear that these things are connected via `fellow_id` not the stock Rails ids.